### PR TITLE
Update SqlsrvMetadata.php

### DIFF
--- a/lib/Kumbia/ActiveRecord/Metadata/SqlsrvMetadata.php
+++ b/lib/Kumbia/ActiveRecord/Metadata/SqlsrvMetadata.php
@@ -38,24 +38,31 @@ class SqlsrvMetadata extends Metadata
      *
      * @return array
      */
-    protected function queryFields($database, $table, $schema = null)
+    protected function queryFields($database, $table, $schema='dbo')
     {
-        $sql = "SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME='$table'";
+        $sql = "SELECT
+            c.name AS field_name,
+            c.is_identity AS is_auto_increment,
+            c.is_nullable,
+            object_definition(c.default_object_id) AS default_value,
+            t.name AS type_field
+        FROM sys.columns c join sys.types t 
+        ON c.system_type_id = t.user_type_id
+        WHERE object_id = object_id('$schema.$table')";
         $describe = Db::get($database)->query($sql);
         $fields = array();
         $pk = Db::get($database)->query("exec sp_pkeys @table_name='$table'");
         $pk = $pk->fetch(PDO::FETCH_OBJ);
         $pk = $pk->COLUMN_NAME;
-        // TODO mejorar este código, la consulta SQL no usa el $schema
-        while (( $value = $describe->fetch(PDO::FETCH_OBJ))) :
-            $fields[$value->COLUMN_NAME] = array(
-                'Type' => $value->DATA_TYPE,
-                'Null' => $value->IS_NULLABLE,
-                'Key' => ($value->COLUMN_NAME == $pk) ? 'PRI' : '',
-                'Default' => $value->COLUMN_DEFAULT,
-                'Auto' => ''
+        while( ( $value = $describe->fetch(PDO::FETCH_OBJ) ) ) :
+            $fields[$value->field_name] = array(
+                'Type' => $value->type_field,
+                'Null' => $value->is_nullable ? 1 : '',
+                'Key' => ($value->field_name == $pk) ? 'PRI' : '',
+                'Default' => str_replace("''", "'", trim($value->default_value, "(')") ),
+                'Auto' => ($value->is_auto_increment) ? 'auto_increment' : ''
             );
-            $this->filterCol($fields[$value->COLUMN_NAME], $value->COLUMN_NAME);
+            $this->filterCol($fields[$value->field_name], $value->field_name);
         endwhile;
         return $fields;
     }


### PR DESCRIPTION
Ampliado la consulta para recoger el dato auto_increment a falta de revisar si son correctos los datos devueltos.
Dudas:
1) ¿ $value->type_field debe ser mayusculas ?
2) ¿ $value->is_nullable es 1 o vacio ?
3) El valor por defecto por lo que he visto el motor añade parentesis y comillas segun el tipo de valor (($int)) ('$string') y 
a parte las comillas simples, las escapa con otra comilla simple delante. Por lo tanto lo que trato de hacer es eliminar esto y no se si es la mejor forma.
4) ¿ $value->is_auto_increment es auto_increment o nada ?